### PR TITLE
fix: syncapigw clientFactory 空指针修复

### DIFF
--- a/runner/syncapigw.go
+++ b/runner/syncapigw.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/TencentBlueKing/beego-runtime/conf"
+	"github.com/TencentBlueKing/bk-apigateway-sdks/apigateway"
 	"github.com/TencentBlueKing/bk-apigateway-sdks/core/bkapi"
 	"github.com/TencentBlueKing/bk-apigateway-sdks/manager"
 	"github.com/sirupsen/logrus"
@@ -64,7 +65,7 @@ func runSyncApigw() {
 		conf.ApigwApiName(),
 		config,
 		definition,
-		nil,
+		apigateway.New,
 	)
 	if err != nil {
 		log.Fatalf("create apigw manager error: %v\n", err)


### PR DESCRIPTION
## Summary

修复 `syncapigw` 中 `manager.NewManager` 的 `clientFactory` 参数传了 `nil` 导致运行时 panic 的问题。

### 错误信息

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
github.com/TencentBlueKing/bk-apigateway-sdks/manager.NewManager(...)
    manager.go:321 +0x1bc
```

### 修复

将 `nil` 替换为 `apigateway.New`，与 `NewDefaultManager` 的行为一致。


Made with [Cursor](https://cursor.com)